### PR TITLE
Mejorar la validación de fechas para los filtros de búsqueda de habitaciones

### DIFF
--- a/src/app/components/buscar-habitaciones/buscar-habitaciones.component.ts
+++ b/src/app/components/buscar-habitaciones/buscar-habitaciones.component.ts
@@ -1288,10 +1288,13 @@ export class BuscarHabitacionesComponent implements OnInit {
     this.errorHuespedes = '';
     this.errorGeneral = '';
 
-    // CA2: Validar fechas
+    // CA2: Validar fechas (servidor/servicio también valida, esto evita bypass por input manual)
+    const fechaInicioISO = this.filtros.fechaInicio || '';
+    const fechaFinISO = this.filtros.fechaFin || '';
+
     const validacionFechas = this.filtrosService.validarFechas(
-      this.filtros.fechaInicio,
-      this.filtros.fechaFin
+      fechaInicioISO,
+      fechaFinISO
     );
 
     if (!validacionFechas.valido) {

--- a/src/app/services/filtros.service.ts
+++ b/src/app/services/filtros.service.ts
@@ -88,13 +88,25 @@ export class FiltrosService {
    * Helper: Validar que fecha fin sea posterior a fecha inicio (CA2)
    */
   validarFechas(fechaInicio: string, fechaFin: string): { valido: boolean; error?: string } {
-    const inicio = new Date(fechaInicio);
-    const fin = new Date(fechaFin);
+    // Parse dates as local dates at midnight to avoid timezone issues
+    const inicio = new Date(fechaInicio + 'T00:00:00');
+    const fin = new Date(fechaFin + 'T00:00:00');
 
     if (isNaN(inicio.getTime()) || isNaN(fin.getTime())) {
       return {
         valido: false,
         error: 'Formato de fecha inválido'
+      };
+    }
+
+    // Hoy a medianoche
+    const hoy = new Date();
+    hoy.setHours(0, 0, 0, 0);
+
+    if (inicio < hoy) {
+      return {
+        valido: false,
+        error: 'La fecha de inicio no puede ser anterior a hoy'
       };
     }
 


### PR DESCRIPTION
La validación de fechas ahora asegura que la fecha de inicio no sea anterior a hoy y analiza las fechas a medianoche para evitar problemas de zona horaria. Esto evita omitir la validación mediante la entrada manual y mejora la fiabilidad de las comprobaciones de fechas en los servicios buscar-habitaciones y filtros.